### PR TITLE
WIP: Support .NET Framework 3.5

### DIFF
--- a/src/Sentry.Protocol/Breadcrumb.cs
+++ b/src/Sentry.Protocol/Breadcrumb.cs
@@ -50,8 +50,11 @@ namespace Sentry.Protocol
         /// Additional parameters that are unsupported by the type are rendered as a key/value table.
         /// </remarks>
         [DataMember(Name = "data", EmitDefaultValue = false)]
+#if LACKS_READONLY_COLLECTIONS
+        public IDictionary<string, string> Data { get; }
+#else
         public IReadOnlyDictionary<string, string> Data { get; }
-
+#endif
         /// <summary>
         /// Dotted strings that indicate what the crumb is or where it comes from.
         /// </summary>
@@ -82,7 +85,11 @@ namespace Sentry.Protocol
         public Breadcrumb(
             string message,
             string type,
+#if LACKS_READONLY_COLLECTIONS
+            IDictionary<string, string> data = null,
+#else
             IReadOnlyDictionary<string, string> data = null,
+#endif
             string category = null,
             BreadcrumbLevel level = default)
         : this(
@@ -101,7 +108,11 @@ namespace Sentry.Protocol
             DateTimeOffset? timestamp = null,
             string message = null,
             string type = null,
+#if LACKS_READONLY_COLLECTIONS
+            IDictionary<string, string> data = null,
+#else
             IReadOnlyDictionary<string, string> data = null,
+#endif
             string category = null,
             BreadcrumbLevel level = default)
         {

--- a/src/Sentry.Protocol/Context/Contexts.cs
+++ b/src/Sentry.Protocol/Context/Contexts.cs
@@ -1,4 +1,8 @@
+#if !LACKS_CONCURRENT_COLLECTIONS
 using System.Collections.Concurrent;
+#else
+using System.Collections.Generic;
+#endif
 using System.Runtime.Serialization;
 
 // ReSharper disable once CheckNamespace
@@ -10,7 +14,12 @@ namespace Sentry.Protocol
     /// <inheritdoc />
     /// <seealso href="https://docs.sentry.io/clientdev/interfaces/contexts/" />
     [DataContract]
-    public class Contexts : ConcurrentDictionary<string, object>
+    public class Contexts :
+#if !LACKS_CONCURRENT_COLLECTIONS
+        ConcurrentDictionary<string, object>
+#else
+        Dictionary<string, object>
+#endif
     {
         /// <summary>
         /// Describes the application.
@@ -85,8 +94,11 @@ namespace Sentry.Protocol
                         value = kv.Value;
                         break;
                 }
-
+#if !LACKS_CONCURRENT_COLLECTIONS
                 to.TryAdd(kv.Key, value);
+#else
+                to.Add(kv.Key, value);
+#endif
             }
         }
     }

--- a/src/Sentry.Protocol/Dsn.cs
+++ b/src/Sentry.Protocol/Dsn.cs
@@ -121,7 +121,7 @@ namespace Sentry
             }
 
             // uri.UserInfo returns empty string instead of null when no user info data is provided
-            if (string.IsNullOrWhiteSpace(uri.UserInfo))
+            if (string.IsNullOrEmpty(uri.UserInfo))
             {
                 if (throwOnError)
                 {
@@ -132,7 +132,7 @@ namespace Sentry
 
             var keys = uri.UserInfo.Split(':');
             var publicKey = keys[0];
-            if (string.IsNullOrWhiteSpace(publicKey))
+            if (string.IsNullOrEmpty(publicKey))
             {
                 if (throwOnError)
                 {
@@ -150,7 +150,7 @@ namespace Sentry
             var path = uri.AbsolutePath.Substring(0, uri.AbsolutePath.LastIndexOf('/'));
             var projectId = uri.AbsoluteUri.Substring(uri.AbsoluteUri.LastIndexOf('/') + 1);
 
-            if (string.IsNullOrWhiteSpace(projectId))
+            if (string.IsNullOrEmpty(projectId))
             {
                 if (throwOnError)
                 {
@@ -169,6 +169,48 @@ namespace Sentry
 
             return Tuple.Create(dsn, projectId, path, secretKey, publicKey, builder.Uri);
         }
+
+#if LACKS_TUPLES
+        private class Tuple<T1, T2, T3, T4, T5, T6>
+        {
+            public T1 Item1 { get; set; }
+            public T2 Item2 { get; set; }
+            public T3 Item3 { get; set; }
+            public T4 Item4 { get; set; }
+            public T5 Item5 { get; set; }
+            public T6 Item6 { get; set; }
+
+            public Tuple(
+                T1 t1,
+                T2 t2,
+                T3 t3,
+                T4 t4,
+                T5 t5,
+                T6 t6)
+            {
+                Item1 = t1;
+                Item2 = t2;
+                Item3 = t3;
+                Item4 = t4;
+                Item5 = t5;
+                Item6 = t6;
+            }
+        }
+
+        private static class Tuple
+        {
+            public static Tuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(
+                T1 t1,
+                T2 t2,
+                T3 t3,
+                T4 t4,
+                T5 t5,
+                T6 t6)
+            {
+                return new Tuple<T1, T2, T3, T4, T5, T6>(t1, t2, t3, t4, t5, t6);
+            }
+        }
+#endif
 
         /// <summary>
         /// The original DSN string used to create this instance

--- a/src/Sentry.Protocol/Sentry.Protocol.csproj
+++ b/src/Sentry.Protocol/Sentry.Protocol.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net46;net45;net35</TargetFrameworks>
     <LangVersion>7.2</LangVersion>
     <PackageId>Sentry.Protocol</PackageId>
     <AssemblyName>Sentry.Protocol</AssemblyName>
@@ -17,6 +17,17 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>HAS_VALUE_TUPLE;$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>LACKS_READONLY_COLLECTIONS;$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
+    <Reference Include="System" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+    <DefineConstants>LACKS_TUPLES;LACKS_READONLY_COLLECTIONS;LACKS_CONCURRENT_COLLECTIONS;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Considering supporting .NET 3.5 to use this library with Unity 5 or lower.

Note: Scope wouldn't be thread-safe. Unity [`Application.logMessageReceivedThreaded`](https://docs.unity3d.com/ScriptReference/Application-logMessageReceivedThreaded.html) is potentially invoked from multiple threads.