### PR TITLE
ref: rename StructuredMessage to standard: logEntry

### DIFF
--- a/src/Sentry.Protocol/LogEntry.cs
+++ b/src/Sentry.Protocol/LogEntry.cs
@@ -17,7 +17,7 @@ namespace Sentry.Protocol
     /// </example>
     /// <seealso href="https://docs.sentry.io/clientdev/interfaces/message/"/>
     [DataContract]
-    public class SentryMessage
+    public class LogEntry
     {
         /// <summary>
         /// The raw message string (uninterpolated)

--- a/src/Sentry.Protocol/SentryEvent.cs
+++ b/src/Sentry.Protocol/SentryEvent.cs
@@ -59,8 +59,16 @@ namespace Sentry
         /// <summary>
         /// Gets the structured message that describes this event
         /// </summary>
+        /// <remarks>
+        /// This helps Sentry group events together as the grouping happens
+        /// on the template message instead of the result string message.
+        /// </remarks>
+        /// <example>
+        /// LogEntry will have a template like: 'user {0} logged in'
+        /// Or structured logging template '{user} has logged in'
+        /// </example>
         [DataMember(Name = "logentry", EmitDefaultValue = false)]
-        public SentryMessage StructuredMessage { get; set; }
+        public LogEntry LogEntry { get; set; }
 
         /// <summary>
         /// Name of the logger (or source) of the event

--- a/test/Sentry.Protocol.Tests/LogEntryTests.cs
+++ b/test/Sentry.Protocol.Tests/LogEntryTests.cs
@@ -3,12 +3,12 @@ using Xunit;
 
 namespace Sentry.Protocol.Tests
 {
-    public class SentryMessageTests
+    public class LogEntryTests
     {
         [Fact]
         public void SerializeObject_AllPropertiesSetToNonDefault_SerializesValidObject()
         {
-            var sut = new SentryMessage
+            var sut = new LogEntry
             {
                 Message = "Message {eventId} {name}",
                 Params = new object[] { 100, "test-name" },
@@ -25,7 +25,7 @@ namespace Sentry.Protocol.Tests
 
         [Theory]
         [MemberData(nameof(TestCases))]
-        public void SerializeObject_TestCase_SerializesAsExpected((SentryMessage msg, string serialized) @case)
+        public void SerializeObject_TestCase_SerializesAsExpected((LogEntry msg, string serialized) @case)
         {
             var actual = JsonSerializer.SerializeObject(@case.msg);
 
@@ -34,10 +34,10 @@ namespace Sentry.Protocol.Tests
 
         public static IEnumerable<object[]> TestCases()
         {
-            yield return new object[] { (new SentryMessage(), "{}") };
-            yield return new object[] { (new SentryMessage { Message = "some message" }, "{\"message\":\"some message\"}") };
-            yield return new object[] { (new SentryMessage { Params = new[] { "param" } }, "{\"params\":[\"param\"]}") };
-            yield return new object[] { (new SentryMessage { Formatted = "some formatted" }, "{\"formatted\":\"some formatted\"}") };
+            yield return new object[] { (new LogEntry(), "{}") };
+            yield return new object[] { (new LogEntry { Message = "some message" }, "{\"message\":\"some message\"}") };
+            yield return new object[] { (new LogEntry { Params = new[] { "param" } }, "{\"params\":[\"param\"]}") };
+            yield return new object[] { (new LogEntry { Formatted = "some formatted" }, "{\"formatted\":\"some formatted\"}") };
         }
     }
 }

--- a/test/Sentry.Protocol.Tests/SentryEventTests.cs
+++ b/test/Sentry.Protocol.Tests/SentryEventTests.cs
@@ -23,7 +23,7 @@ namespace Sentry.Protocol.Tests
                 Level = SentryLevel.Fatal,
                 Logger = "logger",
                 Message = "message",
-                StructuredMessage = new SentryMessage
+                LogEntry = new LogEntry
                 {
                     Message = "structured_message"
                 },


### PR DESCRIPTION
To keep the property on SentryEvent compatible with the other SDKs, name it:

`LogEntry`