### PR TITLE
Add properties to the device class which are needed for Android

### DIFF
--- a/src/Sentry.Protocol/Context/Device.cs
+++ b/src/Sentry.Protocol/Context/Device.cs
@@ -25,6 +25,16 @@ namespace Sentry.Protocol
         [DataMember(Name = "name", EmitDefaultValue = false)]
         public string Name { get; set; }
         /// <summary>
+        /// The manufacturer of the device
+        /// </summary>
+        [DataMember(Name = "manufacturer", EmitDefaultValue = false)]
+        public string Manufacturer { get; set; }
+        /// <summary>
+        /// The brand of the device
+        /// </summary>
+        [DataMember(Name = "brand", EmitDefaultValue = false)]
+        public string Brand { get; set; }
+        /// <summary>
         /// The family of the device.
         /// </summary>
         /// <remarks>
@@ -59,6 +69,16 @@ namespace Sentry.Protocol
         [DataMember(Name = "battery_level", EmitDefaultValue = false)]
         public short? BatteryLevel { get; set; }
         /// <summary>
+        /// True if the device is charging.
+        /// </summary>
+        [DataMember(Name = "charging", EmitDefaultValue = false)]
+        public bool? IsCharging { get; set; }
+        /// <summary>
+        /// True if the device has a internet connection
+        /// </summary>
+        [DataMember(Name = "online", EmitDefaultValue = false)]
+        public bool? IsOnline { get; set; }
+        /// <summary>
         /// This can be a string portrait or landscape to define the orientation of a device.
         /// </summary>
         [DataMember(Name = "orientation", EmitDefaultValue = false)]
@@ -84,6 +104,11 @@ namespace Sentry.Protocol
         [DataMember(Name = "usable_memory", EmitDefaultValue = false)]
         public long? UsableMemory { get; set; }
         /// <summary>
+        /// True, if the device memory is low.
+        /// </summary>
+        [DataMember(Name = "low_memory")]
+        public bool? LowMemory { get; set; }
+        /// <summary>
         /// Total device storage in bytes.
         /// </summary>
         [DataMember(Name = "storage_size", EmitDefaultValue = false)]
@@ -103,6 +128,24 @@ namespace Sentry.Protocol
         /// </summary>
         [DataMember(Name = "external_free_storage", EmitDefaultValue = false)]
         public long? ExternalFreeStorage { get; set; }
+        /// <summary>
+        /// The resolution of the screen.
+        /// </summary>
+        /// <example>
+        /// 800x600
+        /// </example>
+        [DataMember(Name = "screen_resolution", EmitDefaultValue = false)]
+        public string ScreenResolution { get; set; }
+        /// <summary>
+        /// The logical density of the display.
+        /// </summary>
+        [DataMember(Name = "screen_density", EmitDefaultValue = false)]
+        public float? ScreenDensity { get; set; }
+        /// <summary>
+        /// The screen density as dots-per-inch.
+        /// </summary>
+        [DataMember(Name = "screen_dpi", EmitDefaultValue = false)]
+        public int? ScreenDpi { get; set; }
         /// <summary>
         /// A formatted UTC timestamp when the system was booted.
         /// </summary>
@@ -127,11 +170,18 @@ namespace Sentry.Protocol
             => new Device
             {
                 Name = Name,
+                Manufacturer = Manufacturer,
+                Brand = Brand,
                 Architecture = Architecture,
                 BatteryLevel = BatteryLevel,
+                IsCharging = IsCharging,
+                IsOnline = IsOnline,
                 BootTime = BootTime,
                 ExternalFreeStorage = ExternalFreeStorage,
                 ExternalStorageSize = ExternalStorageSize,
+                ScreenResolution = ScreenResolution,
+                ScreenDensity = ScreenDensity,
+                ScreenDpi = ScreenDpi,
                 Family = Family,
                 FreeMemory = FreeMemory,
                 FreeStorage = FreeStorage,
@@ -142,7 +192,8 @@ namespace Sentry.Protocol
                 Simulator = Simulator,
                 StorageSize = StorageSize,
                 Timezone = Timezone,
-                UsableMemory = UsableMemory
+                UsableMemory = UsableMemory,
+                LowMemory = LowMemory
             };
     }
 }

--- a/test/Sentry.Protocol.Tests/Context/DeviceTests.cs
+++ b/test/Sentry.Protocol.Tests/Context/DeviceTests.cs
@@ -25,6 +25,7 @@ namespace Sentry.Protocol.Tests.Context
                 Name = "testing.sentry.io",
                 Architecture = "x64",
                 BatteryLevel = 99,
+                IsCharging = true,
                 BootTime = DateTimeOffset.MaxValue,
                 ExternalFreeStorage = 100_000_000_000_000, // 100 TB
                 ExternalStorageSize = 1_000_000_000_000_000, // 1 PB
@@ -33,12 +34,18 @@ namespace Sentry.Protocol.Tests.Context
                 MemorySize = 500_000_000_000, // 500 GB
                 StorageSize = 100_000_000,
                 FreeStorage = 0,
+                ScreenResolution = "800x600",
+                ScreenDensity = 42,
+                ScreenDpi = 42,
+                Brand = "Brand",
+                Manufacturer = "Manufacturer",
                 Model = "Windows Server 2012 R2",
                 ModelId = "0921309128012",
                 Orientation = DeviceOrientation.Portrait,
                 Simulator = false,
                 Timezone = TimeZoneInfo.Local,
-                UsableMemory = 100
+                UsableMemory = 100,
+                LowMemory = true
             };
 
             var actual = JsonSerializer.SerializeObject(sut);
@@ -46,20 +53,27 @@ namespace Sentry.Protocol.Tests.Context
             Assert.Equal("{\"type\":\"device\","+
                          $"\"timezone\":\"{TimeZoneInfo.Local.Id}\"," +
                          "\"name\":\"testing.sentry.io\"," +
+                         "\"manufacturer\":\"Manufacturer\"," +
+                         "\"brand\":\"Brand\"," +
                          "\"family\":\"Windows\"," +
                          "\"model\":\"Windows Server 2012 R2\"," +
                          "\"model_id\":\"0921309128012\"," +
                          "\"arch\":\"x64\"," +
                          "\"battery_level\":99," +
+                         "\"charging\":true," +
                          "\"orientation\":\"portrait\"," +
                          "\"simulator\":false," +
                          "\"memory_size\":500000000000," +
                          "\"free_memory\":200000000000," +
                          "\"usable_memory\":100," +
+                         "\"low_memory\":true," +
                          "\"storage_size\":100000000," +
                          "\"free_storage\":0," +
                          "\"external_storage_size\":1000000000000000," +
                          "\"external_free_storage\":100000000000000," +
+                         "\"screen_resolution\":\"800x600\"," +
+                         "\"screen_density\":42.0," +
+                         "\"screen_dpi\":42," +
                          "\"boot_time\":\"9999-12-31T23:59:59.9999999+00:00\"}",
                 actual);
         }
@@ -70,43 +84,59 @@ namespace Sentry.Protocol.Tests.Context
             var sut = new Device
             {
                 Name = "name",
+                Brand = "brand",
+                Manufacturer = "manufacturer",
                 Family = "family",
                 Model = "Model",
                 ModelId = "ModelId",
                 Architecture = "Architecture",
                 BatteryLevel = 2,
+                IsCharging = false,
                 Orientation = DeviceOrientation.Portrait,
                 Simulator = true,
                 MemorySize = 3,
                 FreeMemory = 4,
                 UsableMemory = 5,
+                LowMemory = false,
                 StorageSize = 6,
                 FreeStorage = 7,
                 ExternalStorageSize = 8,
                 ExternalFreeStorage = 9,
+                ScreenResolution = "1x1",
+                ScreenDensity = 10,
+                ScreenDpi = 11,
                 BootTime = DateTimeOffset.UtcNow,
                 Timezone = TimeZoneInfo.Utc,
+                IsOnline = false
             };
 
             var clone = sut.Clone();
 
             Assert.Equal(sut.Name, clone.Name);
             Assert.Equal(sut.Family, clone.Family);
+            Assert.Equal(sut.Brand, clone.Brand);
+            Assert.Equal(sut.Manufacturer, clone.Manufacturer);
             Assert.Equal(sut.Model, clone.Model);
             Assert.Equal(sut.ModelId, clone.ModelId);
             Assert.Equal(sut.Architecture, clone.Architecture);
             Assert.Equal(sut.BatteryLevel, clone.BatteryLevel);
+            Assert.Equal(sut.IsCharging, clone.IsCharging);
             Assert.Equal(sut.Orientation, clone.Orientation);
             Assert.Equal(sut.Simulator, clone.Simulator);
             Assert.Equal(sut.MemorySize, clone.MemorySize);
             Assert.Equal(sut.FreeMemory, clone.FreeMemory);
+            Assert.Equal(sut.LowMemory, clone.LowMemory);
             Assert.Equal(sut.UsableMemory, clone.UsableMemory);
             Assert.Equal(sut.StorageSize, clone.StorageSize);
             Assert.Equal(sut.FreeStorage, clone.FreeStorage);
             Assert.Equal(sut.ExternalStorageSize, clone.ExternalStorageSize);
             Assert.Equal(sut.ExternalFreeStorage, clone.ExternalFreeStorage);
+            Assert.Equal(sut.ScreenResolution, clone.ScreenResolution);
+            Assert.Equal(sut.ScreenDensity, clone.ScreenDensity);
+            Assert.Equal(sut.ScreenDpi, clone.ScreenDpi);
             Assert.Equal(sut.BootTime, clone.BootTime);
             Assert.Equal(sut.Timezone, clone.Timezone);
+            Assert.Equal(sut.IsOnline, clone.IsOnline);
         }
 
         [Theory]
@@ -123,19 +153,27 @@ namespace Sentry.Protocol.Tests.Context
             yield return new object[] { (new Device(), "{\"type\":\"device\"}") };
             yield return new object[] { (new Device { Name = "some name" }, "{\"type\":\"device\",\"name\":\"some name\"}") };
             yield return new object[] { (new Device { Orientation = DeviceOrientation.Landscape }, "{\"type\":\"device\",\"orientation\":\"landscape\"}") };
+            yield return new object[] { (new Device { Brand = "some brand" }, "{\"type\":\"device\",\"brand\":\"some brand\"}") };
+            yield return new object[] { (new Device { Manufacturer = "some manufacturer" }, "{\"type\":\"device\",\"manufacturer\":\"some manufacturer\"}") };
             yield return new object[] { (new Device { Family = "some family" }, "{\"type\":\"device\",\"family\":\"some family\"}") };
             yield return new object[] { (new Device { Model = "some model" }, "{\"type\":\"device\",\"model\":\"some model\"}") };
             yield return new object[] { (new Device { ModelId = "some model id" }, "{\"type\":\"device\",\"model_id\":\"some model id\"}") };
             yield return new object[] { (new Device { Architecture = "some arch" }, "{\"type\":\"device\",\"arch\":\"some arch\"}") };
             yield return new object[] { (new Device { BatteryLevel = 1 }, "{\"type\":\"device\",\"battery_level\":1}") };
+            yield return new object[] { (new Device { IsCharging = true }, "{\"type\":\"device\",\"charging\":true}") };
+            yield return new object[] { (new Device { IsOnline = true }, "{\"type\":\"device\",\"online\":true}") };
             yield return new object[] { (new Device { Simulator = false }, "{\"type\":\"device\",\"simulator\":false}") };
             yield return new object[] { (new Device { MemorySize = 1 }, "{\"type\":\"device\",\"memory_size\":1}") };
             yield return new object[] { (new Device { FreeMemory = 1 }, "{\"type\":\"device\",\"free_memory\":1}") };
             yield return new object[] { (new Device { UsableMemory = 1 }, "{\"type\":\"device\",\"usable_memory\":1}") };
+            yield return new object[] { (new Device { LowMemory = true }, "{\"type\":\"device\",\"low_memory\":true}") };
             yield return new object[] { (new Device { StorageSize = 1 }, "{\"type\":\"device\",\"storage_size\":1}") };
             yield return new object[] { (new Device { FreeStorage = 1 }, "{\"type\":\"device\",\"free_storage\":1}") };
             yield return new object[] { (new Device { ExternalStorageSize = 1 }, "{\"type\":\"device\",\"external_storage_size\":1}") };
             yield return new object[] { (new Device { ExternalFreeStorage = 1 }, "{\"type\":\"device\",\"external_free_storage\":1}") };
+            yield return new object[] { (new Device { ScreenResolution = "1x1" }, "{\"type\":\"device\",\"screen_resolution\":\"1x1\"}") };
+            yield return new object[] { (new Device { ScreenDensity = 1 }, "{\"type\":\"device\",\"screen_density\":1.0}") };
+            yield return new object[] { (new Device { ScreenDpi = 1 }, "{\"type\":\"device\",\"screen_dpi\":1}") };
             yield return new object[] { (new Device { BootTime = DateTimeOffset.MaxValue }, "{\"type\":\"device\",\"boot_time\":\"9999-12-31T23:59:59.9999999+00:00\"}") };
             yield return new object[] { (new Device { Timezone = TimeZoneInfo.Utc }, "{\"type\":\"device\",\"timezone\":\"UTC\"}") };
         }


### PR DESCRIPTION
This properties are used in an [native Android event](https://github.com/getsentry/sentry-java/blob/master/sentry-android/src/main/java/io/sentry/android/event/helper/AndroidEventBuilderHelper.java), to use the dot-net version with Xamarin.Android. It would be nice to use them there as well.

I hope that his PR follows the code style of this project. 
