### PR TITLE
fix: Remove stacktrace from event

### DIFF
--- a/src/Sentry.Protocol/SentryEvent.cs
+++ b/src/Sentry.Protocol/SentryEvent.cs
@@ -112,13 +112,6 @@ namespace Sentry
         internal SentryValues<SentryThread> SentryThreadValues { get; set; }
 
         /// <summary>
-        /// Stack trace
-        /// </summary>
-        /// <see href="https://docs.sentry.io/clientdev/interfaces/stacktrace/"/>
-        [DataMember(Name = "stacktrace", EmitDefaultValue = false)]
-        public SentryStackTrace Stacktrace { get; set; }
-
-        /// <summary>
         /// The Sentry Exception interface
         /// </summary>
         public IEnumerable<SentryException> SentryExceptions


### PR DESCRIPTION
Stacktrace belongs to a [Thread](https://github.com/getsentry/sentry-dotnet-protocol/blob/62e6bdb5c481ccc0797bce7fbf05bdf387d15e4d/src/Sentry.Protocol/SentryThread.cs#L41) or an [Exception](https://github.com/getsentry/sentry-dotnet-protocol/blob/master/src/Sentry.Protocol/Exceptions/SentryException.cs#L49).

Resolves #18 

